### PR TITLE
設定ファイルの読み込みでの CUT_CENTER_SPACE の型チェック処理の修正

### DIFF
--- a/src/miz_format.py
+++ b/src/miz_format.py
@@ -28,7 +28,7 @@ def load_settings():
             # CUT_CENTER_SPACE の場合、型チェックを行う
             if setting_key == "CUT_CENTER_SPACE":
                 if not cut_center_space_format_is_valid(setting_value):
-                    print("設定ファイルのCUT_CENTER_SPACEの値が不適切です。")
+                    logging.error("CUT_CENTER_SPACE value in setting file is invalid.")
                     sys.exit(1)
 
                 # 複合キーの型変換

--- a/src/miz_format.py
+++ b/src/miz_format.py
@@ -47,8 +47,10 @@ def cut_center_space_format_is_valid(cut_center_space_value: Any) -> bool:
     if not (isinstance(cut_center_space_value, dict)):
         return False
 
-    for key in cut_center_space_value:
+    for key, value in cut_center_space_value.items():
         if len(key.split()) != 2:
+            return False
+        if type(value) != bool:
             return False
 
     return True

--- a/tests/test_miz_format.py
+++ b/tests/test_miz_format.py
@@ -64,6 +64,11 @@ def test_cut_center_space_format_is_valid2():
 
 
 def test_cut_center_space_format_is_valid3():
+    cut_center_space_value = {": __label": 1}
+    assert (cut_center_space_format_is_valid(cut_center_space_value)) == False
+
+
+def test_cut_center_space_format_is_valid4():
     cut_center_space_value = {": __label": True}
     assert (cut_center_space_format_is_valid(cut_center_space_value)) == True
 


### PR DESCRIPTION
## 内容
- 型が不正だった場合、print 出力していたものをエラーログ出力へ変更
- CUT_CENTER_SPACE の key だけでなく value の型判定を追加