### PR TITLE
配列の範囲外にアクセスするバグを修正

### DIFF
--- a/src/miz_format.py
+++ b/src/miz_format.py
@@ -409,6 +409,7 @@ def adjust_newline_position(token_lines: list[list[ASTToken]]) -> list[list[ASTT
                         tokens[current_pos].text == "scheme"
                         or (
                             tokens[current_pos].text == "theorem"
+                            and current_pos < len(tokens) - 1
                             and tokens[current_pos + 1].token_type == TokenType.IDENTIFIER
                             and tokens[current_pos + 1].identifier_type == IdentifierType.LABEL
                         )


### PR DESCRIPTION
## 内容
- 以下のパターンの1行目において、"theorem" の次のトークン(存在しない)を参照しようとしてバグが発生していたため修正

```
theorem
  for x being object holds x is set;
```