### PR TITLE
Theorem/Schemeブロック終了判定時に、インデントレベルが初期化されないバグを修正

### DIFF
--- a/src/miz_format.py
+++ b/src/miz_format.py
@@ -411,6 +411,7 @@ def adjust_newline_position(token_lines: list[list[ASTToken]]) -> list[list[ASTT
                         tokens[current_pos].text == "scheme"
                         or (
                             tokens[current_pos].text == "theorem"
+                            and current_pos < len(tokens) - 1
                             and tokens[current_pos + 1].token_type == TokenType.IDENTIFIER
                             and tokens[current_pos + 1].identifier_type == IdentifierType.LABEL
                         )

--- a/src/miz_format.py
+++ b/src/miz_format.py
@@ -343,6 +343,7 @@ def determine_body_part_indentation_widths(
             ):
                 current_block_type = ""
                 current_block_level = 0
+                current_indentation_level = 0
 
         # Schemeブロックの開始/終了判定
         if first_token_text == "scheme":
@@ -352,7 +353,7 @@ def determine_body_part_indentation_widths(
         elif current_block_type == "scheme":
             if first_token_text == "end" and current_block_level == 0:
                 current_block_type = ""
-                current_block_level = 0
+                current_indentation_level = 0
 
     return indentation_widths
 

--- a/src/miz_format.py
+++ b/src/miz_format.py
@@ -39,7 +39,7 @@ def load_settings():
 
 def output(output_lines):
     # with open(miz_path, "w") as f:
-    with open("data/result.miz", "w") as f:
+    with open("tests/data/result.miz", "w") as f:
         f.writelines([f"{line}\n" for line in output_lines])
 
 

--- a/tests/test_miz_format.py
+++ b/tests/test_miz_format.py
@@ -208,12 +208,18 @@ def test_determine_body_part_indentation_widths1():
 
 # Theoremブロック(Simple-Justification)を含む場合
 def test_determine_body_part_indentation_widths2():
-    assert (determine_body_part_indentation_widths(generate_token_lines(token_table2)[30:35])) == [
+    assert (determine_body_part_indentation_widths(generate_token_lines(token_table2)[30:41])) == [
         0,
         2,
         2,
         2,
         0,
+        0,
+        0,
+        2,
+        2,
+        2,
+        2
     ]
 
 


### PR DESCRIPTION
## 内容
- Theorem/Schemeブロック終了時、インデントレベルが初期化されておらず、以降のインデントにズレが出ていたため修正
- Schemeブロック終了時、不要な変数代入を削除

## レビュー対象外
- 3a8b87465817b570fbb9ce8324db420163f26dee
  - #16 の内容