### PR TITLE
ディレクトリ構成の変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dmypy.json
 .pyre/
 
 others/
+tools/

--- a/src/formatter/formatter.py
+++ b/src/formatter/formatter.py
@@ -1,105 +1,17 @@
 import sys
 import os
-import json
 import utils.option as option
 import logging
 import itertools
 from typing import Any
-import re
 
 
 from py_miz_controller import (
-    MizController,
     TokenType,
     KeywordType,
     IdentifierType,
     ASTToken,
-    ASTBlock,
-    ASTStatement,
-    StatementType,
-    BlockType,
 )
-
-
-def main(argv):
-    os.environ["ENV"] = ""
-    _, miz_path, vct_path, user_settings = argv
-    user_settings = json.loads(user_settings)
-    miz_controller = MizController()
-    miz_controller.exec_file(miz_path, vct_path)
-    token_table = miz_controller.token_table
-    ast_root = miz_controller.ast_root
-
-    override_settings(user_settings)
-    load_settings()
-    set_formatted_text(ast_root, token_table)
-    formatted_lines = format(miz_controller, token_table)
-    output(miz_path, formatted_lines)
-
-
-# デフォルトの項目値を設定
-def load_settings():
-    with open("{}/default_settings.json".format(os.path.dirname(__file__)), "r") as f:
-        settings = json.load(f)
-        for setting_key, setting_value in settings.items():
-            # CUT_CENTER_SPACE の場合、型チェックを行う
-            if setting_key == "CUT_CENTER_SPACE":
-                if not cut_center_space_format_is_valid(setting_value):
-                    logging.error("CUT_CENTER_SPACE value in setting file is invalid.")
-                    sys.exit(1)
-
-                # 複合キーの型変換
-                setting_value = {tuple(k.split()): v for k, v in setting_value.items()}
-
-            if not hasattr(option, setting_key):
-                setattr(option, setting_key, setting_value)
-
-
-# ユーザーが指定した項目値を設定
-def override_settings(user_settings: dict):
-    for setting_key, setting_value in user_settings.items():
-        # バリデーションチェック
-        if setting_key == "CUT_CENTER_SPACE":
-            if cut_center_space_format_is_valid(setting_value):
-                # 複合キーの型変換
-                setting_value = {tuple(k.split()): v for k, v in setting_value.items()}
-            else:
-                continue
-        elif setting_key in [
-            "MAX_LINE_LENGTH",
-            "STANDARD_INDENTATION_WIDTH",
-            "ENVIRON_DIRECTIVE_INDENTATION_WIDTH",
-            "ENVIRON_LINE_INDENTATION_WIDTH",
-        ]:
-            if re.fullmatch(r"\d+", setting_value):
-                setting_value = int(setting_value)
-            else:
-                continue
-        elif setting_key in ["CUT_LEFT_SPACE", "CUT_RIGHT_SPACE"]:
-            if type(setting_value) != list:
-                continue
-        else:
-            continue
-
-        setattr(option, setting_key, setting_value)
-
-
-def output(miz_path, output_lines):
-    with open(miz_path, "w") as f:
-        f.writelines([f"{line}\n" for line in output_lines])
-
-
-def cut_center_space_format_is_valid(cut_center_space_value: Any) -> bool:
-    if not (isinstance(cut_center_space_value, dict)):
-        return False
-
-    for key, value in cut_center_space_value.items():
-        if len(key.split()) != 2:
-            return False
-        if type(value) != bool:
-            return False
-
-    return True
 
 
 # token.identifier_type = IdentifierType.LABEL の場合、"__label" を返す
@@ -213,13 +125,6 @@ def convert_token_lines_to_text_arrays(token_lines: list[list[ASTToken]]) -> lis
 
     return texts
 
-
-def format(miz_controller, token_table) -> list[str]:
-    token_lines = generate_token_lines(token_table)
-    env_part_token_lines, body_part_token_lines = split_into_env_and_body_part(token_lines)
-    env_part_lines = format_env_part(miz_controller, env_part_token_lines)
-    body_part_lines = format_body_part(miz_controller, body_part_token_lines)
-    return env_part_lines + body_part_lines
 
 
 def format_env_part(miz_controller, env_part_token_lines: list[list[ASTToken]]) -> list[str]:
@@ -551,106 +456,9 @@ def find_first_no_empty_array_i(array) -> int:
             return i
 
 
-def generate_block_ranges(ast_root) -> list[list[int]]:
-    block_ranges: list[list[int]] = []
-    for i in range(ast_root.child_component_num):
-        ast_component = ast_root.child_component(i)
-
-        if type(ast_component) == ASTBlock:
-            if (
-                i != 0
-                and type(ast_root.child_component(i).block_type == BlockType.PROOF)
-                and type(ast_root.child_component(i - 1)) == ASTStatement
-                and ast_root.child_component(i - 1).statement_type == StatementType.SCHEME
-            ):
-                # Schemeブロック内でproofブロックが出現する場合、
-                # Schemeブロック先頭からproofブロック末尾までをまとめて一つのブロックとみなす
-                block_ranges[-1][1] = ast_component.last_token.id
-            else:
-                block_ranges.append([ast_component.first_token.id, ast_component.last_token.id])
-        elif ast_component.statement_type == StatementType.SCHEME:
-            block_ranges.append(
-                [ast_component.range_first_token.id, ast_component.range_last_token.id]
-            )
-
-    return block_ranges
-
-
-def generate_token_blocks(ast_root, token_table) -> list[list[ASTToken]]:
-    block_ranges = generate_block_ranges(ast_root)
-
-    if len(block_ranges) == 0:
-        return []
-
-    first_token_id, last_token_id = block_ranges.pop(0)
-
-    token_blocks = []
-    token_block = []
-    is_in_block = False
-
-    for i in range(token_table.token_num):
-        token = token_table.token(i)
-
-        if token.id == first_token_id:
-            is_in_block = True
-
-        if is_in_block:
-            token_block.append(token)
-
-        if token.id == last_token_id:
-            is_in_block = False
-            token_blocks.append(token_block)
-            token_block = []
-
-            if len(block_ranges) == 0:
-                return token_blocks
-            first_token_id, last_token_id = block_ranges.pop(0)
-
-
-# チェック対象のラベルに対して、{トークンID: ラベル名} のリストを返す
-def generate_label_mapping(token_blocks) -> dict[int, str]:
-    label_mapping = {}
-    for token_block in token_blocks:
-        # label_var_counts = {ラベル変数名: カウント, ...}
-        # "A1"の"A"をラベル変数名とする
-        label_var_counts: dict[str, int] = {}
-        for i in range(len(token_block)):
-            token = token_block[i]
-            if (
-                token.token_type == TokenType.IDENTIFIER
-                and token.identifier_type == IdentifierType.LABEL
-                and token_block[i - 1].text != ":"  # :Def: を除外
-                and token.ref_token is None
-            ):
-                label_var = (
-                    re.match(r"^(.*?)\d+$", token.text).group(1)
-                    if re.search(r"\d+$", token.text)
-                    else token.text
-                )
-                # 初めて登場するラベル変数名の場合、カウントを初期化
-                if label_var not in label_var_counts.keys():
-                    label_var_counts[label_var] = 1
-
-                label_mapping[token.id] = f"{label_var}{label_var_counts[label_var]}"
-                label_var_counts[label_var] += 1
-
-    return label_mapping
-
-
-def set_formatted_text(ast_root, token_table):
-    label_mapping = generate_label_mapping(generate_token_blocks(ast_root, token_table))
-    for i in range(token_table.token_num):
-        token = token_table.token(i)
-        token_id = token.ref_token.id if token.ref_token else token.id
-        if (
-            token.token_type == TokenType.IDENTIFIER
-            and token.identifier_type == IdentifierType.LABEL
-            and token_id in label_mapping.keys()
-        ):
-            token.set_formatted_text(label_mapping[token_id])
-        else:
-            token.set_formatted_text(token.text)
-
-
-if __name__ == "__main__":
-    main(sys.argv)
+def format(miz_controller, token_table) -> list[str]:
+    token_lines = generate_token_lines(token_table)
+    env_part_token_lines, body_part_token_lines = split_into_env_and_body_part(token_lines)
+    env_part_lines = format_env_part(miz_controller, env_part_token_lines)
+    body_part_lines = format_body_part(miz_controller, body_part_token_lines)
+    return env_part_lines + body_part_lines

--- a/src/linter/linter.py
+++ b/src/linter/linter.py
@@ -1,0 +1,2 @@
+def lint():
+  print("lint")

--- a/src/main.py
+++ b/src/main.py
@@ -34,10 +34,10 @@ def main(argv):
     set_formatted_text(ast_root, token_table)
 
     match mode:
-      case "-f" | "-format":
+      case "-f" | "--format":
         formatted_lines = format(miz_controller, token_table)
         output(miz_path, formatted_lines)
-      case "-l" | "-lint":
+      case "-l" | "--lint":
         lint()
       case _:
         pass

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,212 @@
+import sys
+import os
+import json
+import utils.option as option
+import logging
+from typing import Any
+import re
+from formatter.formatter import format
+from linter.linter import lint
+
+
+from py_miz_controller import (
+    MizController,
+    TokenType,
+    IdentifierType,
+    ASTToken,
+    ASTBlock,
+    ASTStatement,
+    StatementType,
+    BlockType,
+)
+
+def main(argv):
+    os.environ["ENV"] = ""
+    _, mode, miz_path, vct_path, user_settings = argv
+    user_settings = json.loads(user_settings)
+    miz_controller = MizController()
+    miz_controller.exec_file(miz_path, vct_path)
+    token_table = miz_controller.token_table
+    ast_root = miz_controller.ast_root
+
+    override_settings(user_settings)
+    load_settings()
+    set_formatted_text(ast_root, token_table)
+
+    match mode:
+      case "-f" | "-format":
+        formatted_lines = format(miz_controller, token_table)
+        output(miz_path, formatted_lines)
+      case "-l" | "-lint":
+        lint()
+      case _:
+        pass
+
+
+# ユーザーが指定した項目値を設定
+def override_settings(user_settings: dict):
+    for setting_key, setting_value in user_settings.items():
+        # バリデーションチェック
+        if setting_key == "CUT_CENTER_SPACE":
+            if cut_center_space_format_is_valid(setting_value):
+                # 複合キーの型変換
+                setting_value = {tuple(k.split()): v for k, v in setting_value.items()}
+            else:
+                continue
+        elif setting_key in [
+            "MAX_LINE_LENGTH",
+            "STANDARD_INDENTATION_WIDTH",
+            "ENVIRON_DIRECTIVE_INDENTATION_WIDTH",
+            "ENVIRON_LINE_INDENTATION_WIDTH",
+        ]:
+            if re.fullmatch(r"\d+", setting_value):
+                setting_value = int(setting_value)
+            else:
+                continue
+        elif setting_key in ["CUT_LEFT_SPACE", "CUT_RIGHT_SPACE"]:
+            if type(setting_value) != list:
+                continue
+        else:
+            continue
+
+        setattr(option, setting_key, setting_value)
+
+
+# デフォルトの項目値を設定
+def load_settings():
+    with open("{}/default_settings.json".format(os.path.dirname(__file__)), "r") as f:
+        settings = json.load(f)
+        for setting_key, setting_value in settings.items():
+            # CUT_CENTER_SPACE の場合、型チェックを行う
+            if setting_key == "CUT_CENTER_SPACE":
+                if not cut_center_space_format_is_valid(setting_value):
+                    logging.error("CUT_CENTER_SPACE value in setting file is invalid.")
+                    sys.exit(1)
+
+                # 複合キーの型変換
+                setting_value = {tuple(k.split()): v for k, v in setting_value.items()}
+
+            if not hasattr(option, setting_key):
+                setattr(option, setting_key, setting_value)
+
+
+def set_formatted_text(ast_root, token_table):
+    label_mapping = generate_label_mapping(generate_token_blocks(ast_root, token_table))
+    for i in range(token_table.token_num):
+        token = token_table.token(i)
+        token_id = token.ref_token.id if token.ref_token else token.id
+        if (
+            token.token_type == TokenType.IDENTIFIER
+            and token.identifier_type == IdentifierType.LABEL
+            and token_id in label_mapping.keys()
+        ):
+            token.set_formatted_text(label_mapping[token_id])
+        else:
+            token.set_formatted_text(token.text)
+
+
+def output(miz_path, output_lines):
+    with open(miz_path, "w") as f:
+        f.writelines([f"{line}\n" for line in output_lines])
+
+
+def cut_center_space_format_is_valid(cut_center_space_value: Any) -> bool:
+    if not (isinstance(cut_center_space_value, dict)):
+        return False
+
+    for key, value in cut_center_space_value.items():
+        if len(key.split()) != 2:
+            return False
+        if type(value) != bool:
+            return False
+
+    return True
+
+# チェック対象のラベルに対して、{トークンID: ラベル名} のリストを返す
+def generate_label_mapping(token_blocks) -> dict[int, str]:
+    label_mapping = {}
+    for token_block in token_blocks:
+        # label_var_counts = {ラベル変数名: カウント, ...}
+        # "A1"の"A"をラベル変数名とする
+        label_var_counts: dict[str, int] = {}
+        for i in range(len(token_block)):
+            token = token_block[i]
+            if (
+                token.token_type == TokenType.IDENTIFIER
+                and token.identifier_type == IdentifierType.LABEL
+                and token_block[i - 1].text != ":"  # :Def: を除外
+                and token.ref_token is None
+            ):
+                label_var = (
+                    re.match(r"^(.*?)\d+$", token.text).group(1)
+                    if re.search(r"\d+$", token.text)
+                    else token.text
+                )
+                # 初めて登場するラベル変数名の場合、カウントを初期化
+                if label_var not in label_var_counts.keys():
+                    label_var_counts[label_var] = 1
+
+                label_mapping[token.id] = f"{label_var}{label_var_counts[label_var]}"
+                label_var_counts[label_var] += 1
+
+    return label_mapping
+
+
+def generate_token_blocks(ast_root, token_table) -> list[list[ASTToken]]:
+    block_ranges = generate_block_ranges(ast_root)
+
+    if len(block_ranges) == 0:
+        return []
+
+    first_token_id, last_token_id = block_ranges.pop(0)
+
+    token_blocks = []
+    token_block = []
+    is_in_block = False
+
+    for i in range(token_table.token_num):
+        token = token_table.token(i)
+
+        if token.id == first_token_id:
+            is_in_block = True
+
+        if is_in_block:
+            token_block.append(token)
+
+        if token.id == last_token_id:
+            is_in_block = False
+            token_blocks.append(token_block)
+            token_block = []
+
+            if len(block_ranges) == 0:
+                return token_blocks
+            first_token_id, last_token_id = block_ranges.pop(0)
+
+
+def generate_block_ranges(ast_root) -> list[list[int]]:
+    block_ranges: list[list[int]] = []
+    for i in range(ast_root.child_component_num):
+        ast_component = ast_root.child_component(i)
+
+        if type(ast_component) == ASTBlock:
+            if (
+                i != 0
+                and type(ast_root.child_component(i).block_type == BlockType.PROOF)
+                and type(ast_root.child_component(i - 1)) == ASTStatement
+                and ast_root.child_component(i - 1).statement_type == StatementType.SCHEME
+            ):
+                # Schemeブロック内でproofブロックが出現する場合、
+                # Schemeブロック先頭からproofブロック末尾までをまとめて一つのブロックとみなす
+                block_ranges[-1][1] = ast_component.last_token.id
+            else:
+                block_ranges.append([ast_component.first_token.id, ast_component.last_token.id])
+        elif ast_component.statement_type == StatementType.SCHEME:
+            block_ranges.append(
+                [ast_component.range_first_token.id, ast_component.range_last_token.id]
+            )
+
+    return block_ranges
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -2,10 +2,12 @@
 
 import os
 import pytest
-from src.miz_format import *
+from main import load_settings, generate_token_blocks
+from formatter.formatter import *
 import pathlib, sys
-import re
 import yaml
+from py_miz_controller import MizController
+
 
 parent_dir = str(pathlib.Path(__file__).parent.parent.parent)
 sys.path.append(parent_dir)
@@ -58,32 +60,6 @@ real_1_miz_controller = MizController()
 real_1_miz_controller.exec_file(f"{TEST_DIR}/data/real_1.miz", f"{TEST_DIR}/data/mml.vct")
 real_1_token_table = real_1_miz_controller.token_table
 real_1_ast_root = real_1_miz_controller.ast_root
-
-
-label_map_miz_controller = MizController()
-label_map_miz_controller.exec_file(f"{TEST_DIR}/data/label_map.miz", f"{TEST_DIR}/data/mml.vct")
-label_map_token_table = label_map_miz_controller.token_table
-label_map_ast_root = label_map_miz_controller.ast_root
-
-
-def test_cut_center_space_format_is_valid1():
-    cut_center_space_value = 100
-    assert (cut_center_space_format_is_valid(cut_center_space_value)) == False
-
-
-def test_cut_center_space_format_is_valid2():
-    cut_center_space_value = {":": True}
-    assert (cut_center_space_format_is_valid(cut_center_space_value)) == False
-
-
-def test_cut_center_space_format_is_valid3():
-    cut_center_space_value = {": __label": 1}
-    assert (cut_center_space_format_is_valid(cut_center_space_value)) == False
-
-
-def test_cut_center_space_format_is_valid4():
-    cut_center_space_value = {": __label": True}
-    assert (cut_center_space_format_is_valid(cut_center_space_value)) == True
 
 
 def test_convert_to_token_representative_name1():
@@ -463,65 +439,4 @@ def test_generate_token_blocks():
         "coherence",
         ";",
         "end",
-    ]
-
-
-def test_generate_label_mapping():
-    assert (
-        generate_label_mapping(generate_token_blocks(label_map_ast_root, label_map_token_table))
-    ) == {
-        128: "A1",
-        210: "A2",
-        238: "A3",
-        308: "A4",
-        314: "A5",
-        377: "A6",
-        383: "A7",
-        401: "A8",
-        452: "A9",
-        496: "A10",
-        503: "A11",
-        556: "A12",
-        562: "A13",
-        599: "A14",
-        605: "A15",
-        705: "A1",
-        711: "A2",
-        731: "A3",
-        763: "A4",
-    }
-
-
-def test_set_formatted_text():
-    os.environ["ENV"] = ""
-    set_formatted_text(label_map_ast_root, label_map_token_table)
-    assert [
-        label_map_token_table.token(i).formatted_text
-        for i in range(label_map_token_table.token_num)
-        if (
-            label_map_token_table.token(i).token_type == TokenType.IDENTIFIER
-            and label_map_token_table.token(i).identifier_type == IdentifierType.LABEL
-            and label_map_token_table.token(i).ref_token is None
-            and not re.match(r"Def|Th", label_map_token_table.token(i).text)
-        )
-    ] == [
-        "A1",
-        "A2",
-        "A3",
-        "A4",
-        "A5",
-        "A6",
-        "A7",
-        "A8",
-        "A9",
-        "A10",
-        "A11",
-        "A12",
-        "A13",
-        "A14",
-        "A15",
-        "A1",
-        "A2",
-        "A3",
-        "A4",
     ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,102 @@
+# flake8: noqa
+
+import os
+import pytest
+from main import *
+import pathlib, sys
+import re
+
+parent_dir = str(pathlib.Path(__file__).parent.parent.parent)
+sys.path.append(parent_dir)
+
+os.environ["ENV"] = "test"
+
+TEST_DIR = f"{os.getcwd()}/tests"
+
+load_settings()
+
+label_map_miz_controller = MizController()
+label_map_miz_controller.exec_file(f"{TEST_DIR}/data/label_map.miz", f"{TEST_DIR}/data/mml.vct")
+label_map_token_table = label_map_miz_controller.token_table
+label_map_ast_root = label_map_miz_controller.ast_root
+
+
+def test_cut_center_space_format_is_valid1():
+    cut_center_space_value = 100
+    assert (cut_center_space_format_is_valid(cut_center_space_value)) == False
+
+
+def test_cut_center_space_format_is_valid2():
+    cut_center_space_value = {":": True}
+    assert (cut_center_space_format_is_valid(cut_center_space_value)) == False
+
+
+def test_cut_center_space_format_is_valid3():
+    cut_center_space_value = {": __label": 1}
+    assert (cut_center_space_format_is_valid(cut_center_space_value)) == False
+
+
+def test_cut_center_space_format_is_valid4():
+    cut_center_space_value = {": __label": True}
+    assert (cut_center_space_format_is_valid(cut_center_space_value)) == True
+
+
+def test_generate_label_mapping():
+    assert (
+        generate_label_mapping(generate_token_blocks(label_map_ast_root, label_map_token_table))
+    ) == {
+        128: "A1",
+        210: "A2",
+        238: "A3",
+        308: "A4",
+        314: "A5",
+        377: "A6",
+        383: "A7",
+        401: "A8",
+        452: "A9",
+        496: "A10",
+        503: "A11",
+        556: "A12",
+        562: "A13",
+        599: "A14",
+        605: "A15",
+        705: "A1",
+        711: "A2",
+        731: "A3",
+        763: "A4",
+    }
+
+
+def test_set_formatted_text():
+    os.environ["ENV"] = ""
+    set_formatted_text(label_map_ast_root, label_map_token_table)
+    assert [
+        label_map_token_table.token(i).formatted_text
+        for i in range(label_map_token_table.token_num)
+        if (
+            label_map_token_table.token(i).token_type == TokenType.IDENTIFIER
+            and label_map_token_table.token(i).identifier_type == IdentifierType.LABEL
+            and label_map_token_table.token(i).ref_token is None
+            and not re.match(r"Def|Th", label_map_token_table.token(i).text)
+        )
+    ] == [
+        "A1",
+        "A2",
+        "A3",
+        "A4",
+        "A5",
+        "A6",
+        "A7",
+        "A8",
+        "A9",
+        "A10",
+        "A11",
+        "A12",
+        "A13",
+        "A14",
+        "A15",
+        "A1",
+        "A2",
+        "A3",
+        "A4",
+    ]


### PR DESCRIPTION
## 内容
リント機能を追加するため、ファイルの構成を変更。フォーマッターの挙動に変更はありません。
- miz_format.py の内容を、前処理 (main.py) とフォーマット処理 (formatter.py) で分離。
- リンター処理用のファイル (linter.py) を追加。

コマンドライン引数に、フォーマット or リント を選択する引数を追加。
- `-l` `--lint` : リント機能
- `-f` `--format` : フォーマット機能



close #36 