### PR TITLE
冗長引用ラベルの検知を実装

### DIFF
--- a/src/linter/linter.py
+++ b/src/linter/linter.py
@@ -81,25 +81,28 @@ def check_redundant_statement_label(ast_block, token_lines):
     for statement, next_statement in zip(
         ast_statements[: len(ast_statements) - 1], ast_statements[1:]
     ):
-        # 式にラベルが1つだけ振られていることをチェック
+        # 式にラベルが振られていることをチェック
         statement_tokens = extract_statement_tokens(
             token_lines,
             statement.range_first_token.line_number,
             statement.range_last_token.line_number,
         )
-        referenced_labels = []
+        referenced_label = None
         for token in statement_tokens:
+            # `that`は2つ以上文を取れるため直後で`then`は使えない
+            if token.text == "that":
+                break
+
             if (
                 token.token_type == TokenType.IDENTIFIER
                 and token.identifier_type == IdentifierType.LABEL
                 and not token.ref_token
             ):
-                referenced_labels.append(token)
+                referenced_label = token
+                break
 
-        if len(referenced_labels) != 1:
+        if not referenced_label:
             continue
-
-        referenced_label = referenced_labels[0]
 
         # 直後の式がラベルを引用しているかどうかチェック
         next_statement_tokens = extract_statement_tokens(

--- a/src/linter/linter.py
+++ b/src/linter/linter.py
@@ -1,27 +1,129 @@
 import logging
 import utils.option as option
+import itertools
 from py_miz_controller import (
+    ASTStatement,
     BlockType,
     ElementType,
+    ASTToken,
+    TokenType,
+    IdentifierType,
 )
 
 
 def lint(miz_controller):
-  ast_root = miz_controller.ast_root
+    ast_root = miz_controller.ast_root
+    token_table = miz_controller.token_table
+    token_lines = generate_token_lines(token_table)
 
-  check_long_proof(ast_root)
+    check_long_proof(ast_root)
+    check_redundant_statement_label(ast_root, token_lines)
 
 
 def check_long_proof(ast_root):
-  if not(ast_root.child_component_num): return
+    if not (ast_root.child_component_num):
+        return
 
-  for i in range(ast_root.child_component_num):
-    ast_component = ast_root.child_component(i)
-    if ast_component.element_type != ElementType.BLOCK: continue
+    for i in range(ast_root.child_component_num):
+        ast_component = ast_root.child_component(i)
+        if ast_component.element_type != ElementType.BLOCK:
+            continue
 
-    if ast_component.block_type == BlockType.PROOF:
-      if ast_component.last_token.line_number - ast_component.first_token.line_number + 1 <= option.MAX_PROOF_LINE_NUMBER: continue
+        if ast_component.block_type == BlockType.PROOF:
+            if (
+                ast_component.last_token.line_number
+                - ast_component.first_token.line_number
+                + 1
+                <= option.MAX_PROOF_LINE_NUMBER
+            ):
+                continue
 
-      logging.error(f'Proof too long [Ln {ast_component.first_token.line_number}, Col {ast_component.first_token.column_number}]')
-    else:
-      check_long_proof(ast_component)
+            logging.error(
+                f"Proof too long [Ln {ast_component.first_token.line_number}, Col {ast_component.first_token.column_number}]"
+            )
+        else:
+            check_long_proof(ast_component)
+
+
+def generate_token_lines(token_table) -> list[list[ASTToken]]:
+    token_lines: list[list] = [[] for _ in range(token_table.last_token.line_number)]
+
+    for i in range(token_table.token_num):
+        token = token_table.token(i)
+        token_lines[token.line_number - 1].append(token)
+
+    return token_lines
+
+
+def extract_ast_statements(ast_block) -> list[ASTStatement]:
+    ast_statements = []
+    for i in range(ast_block.child_component_num):
+        if ast_block.child_component(i).element_type == ElementType.STATEMENT:
+            ast_statements.append(ast_block.child_component(i))
+
+    return ast_statements
+
+
+def extract_statement_tokens(
+    token_lines, start_line_number, end_line_number
+) -> list[ASTToken]:
+    return list(
+        itertools.chain.from_iterable(
+            token_lines[start_line_number - 1 : end_line_number]
+        )
+    )
+
+
+# 直前の式の引用のためにラベルを使用しているとき警告を出す
+def check_redundant_statement_label(ast_block, token_lines):
+    # 式を2行ずつ見ていく
+    ast_statements = extract_ast_statements(ast_block)
+    for statement, next_statement in zip(
+        ast_statements[: len(ast_statements) - 1], ast_statements[1:]
+    ):
+        # 式にラベルが1つだけ振られていることをチェック
+        statement_tokens = extract_statement_tokens(
+            token_lines,
+            statement.range_first_token.line_number,
+            statement.range_last_token.line_number,
+        )
+        referenced_labels = []
+        for token in statement_tokens:
+            if (
+                token.token_type == TokenType.IDENTIFIER
+                and token.identifier_type == IdentifierType.LABEL
+                and not token.ref_token
+            ):
+                referenced_labels.append(token)
+
+        if len(referenced_labels) != 1:
+            continue
+
+        referenced_label = referenced_labels[0]
+
+        # 直後の式がラベルを引用しているかどうかチェック
+        next_statement_tokens = extract_statement_tokens(
+            token_lines,
+            next_statement.range_first_token.line_number,
+            next_statement.range_last_token.line_number,
+        )
+        reference_labels = []
+        for i, token in enumerate(next_statement_tokens):
+            if token.text == "by":
+                reference_labels = [
+                    token for token in next_statement_tokens[i + 1 :] if token.ref_token
+                ]
+                break
+
+        for token in reference_labels:
+            if token.ref_token == referenced_label:
+                logging.error(
+                    f"`{referenced_label.text}` is redundant citation label. Use `then` to omit the label [Ln {token.line_number}, Col {token.column_number}]"
+                )
+                break
+
+    # 入れ子のブロックをさらに見に行く
+    for i in range(ast_block.child_component_num):
+        child_component = ast_block.child_component(i)
+        if child_component.element_type == ElementType.BLOCK:
+            check_redundant_statement_label(child_component, token_lines)

--- a/src/linter/linter.py
+++ b/src/linter/linter.py
@@ -64,7 +64,7 @@ def extract_ast_statements(ast_block) -> list[ASTStatement]:
     return ast_statements
 
 
-def extract_statement_tokens(
+def extract_ast_statement_tokens(
     token_lines, start_line_number, end_line_number
 ) -> list[ASTToken]:
     return list(
@@ -82,7 +82,7 @@ def check_redundant_statement_label(ast_block, token_lines):
         ast_statements[: len(ast_statements) - 1], ast_statements[1:]
     ):
         # 式にラベルが振られていることをチェック
-        statement_tokens = extract_statement_tokens(
+        statement_tokens = extract_ast_statement_tokens(
             token_lines,
             statement.range_first_token.line_number,
             statement.range_last_token.line_number,
@@ -105,7 +105,7 @@ def check_redundant_statement_label(ast_block, token_lines):
             continue
 
         # 直後の式がラベルを引用しているかどうかチェック
-        next_statement_tokens = extract_statement_tokens(
+        next_statement_tokens = extract_ast_statement_tokens(
             token_lines,
             next_statement.range_first_token.line_number,
             next_statement.range_last_token.line_number,

--- a/tests/data/redundant_label.miz
+++ b/tests/data/redundant_label.miz
@@ -1,0 +1,118 @@
+:: Zero Based Finite Sequences
+::  by Tetsuya Tsunetou , Grzegorz Bancerek and Yatsuka Nakamura
+::
+:: Received September 28, 2001
+:: Copyright (c) 2001-2021 Association of Mizar Users
+::           (Stowarzyszenie Uzytkownikow Mizara, Bialystok, Poland).
+:: This code can be distributed under the GNU General Public Licence
+:: version 3.0 or later, or the Creative Commons Attribution-ShareAlike
+:: License version 3.0 or later, subject to the binding interpretation
+:: detailed in file COPYING.interpretation.
+:: See COPYING.GPL and COPYING.CC-BY-SA for the full text of these
+:: licenses, or see http://www.gnu.org/licenses/gpl.html and
+:: http://creativecommons.org/licenses/by-sa/3.0/.
+
+environ
+
+ vocabularies NUMBERS, SUBSET_1, FUNCT_1, ARYTM_3, XXREAL_0, XBOOLE_0, TARSKI,
+      NAT_1, ORDINAL1, FINSEQ_1, CARD_1, FINSET_1, RELAT_1, PARTFUN1, FUNCOP_1,
+      ORDINAL4, ORDINAL2, ARYTM_1, REAL_1, ZFMISC_1, FUNCT_4, VALUED_0,
+      AFINSQ_1, PRGCOR_2, CAT_1, AMISTD_1, AMISTD_3, AMISTD_2, VALUED_1,
+      CONNSP_3, XCMPLX_0;
+ notations TARSKI, XBOOLE_0, ZFMISC_1, SUBSET_1, RELAT_1, FUNCT_1, ORDINAL1,
+      CARD_1, ORDINAL2, NUMBERS, ORDINAL4, XCMPLX_0, XREAL_0, NAT_1, PARTFUN1,
+      BINOP_1, FINSOP_1, NAT_D, FINSET_1, FINSEQ_1, FUNCOP_1, FUNCT_4, FUNCT_7,
+      XXREAL_0, VALUED_0, VALUED_1;
+ constructors WELLORD2, FUNCT_4, XXREAL_0, ORDINAL4, FUNCT_7, ORDINAL3,
+      VALUED_1, ENUMSET1, NAT_D, XXREAL_2, BINOP_1, FINSOP_1, RELSET_1, CARD_1,
+      NUMBERS;
+ registrations XBOOLE_0, SUBSET_1, RELAT_1, FUNCT_1, ORDINAL1, FUNCOP_1,
+      XXREAL_0, XREAL_0, NAT_1, CARD_1, ORDINAL2, NUMBERS, VALUED_1, XXREAL_2,
+      MEMBERED, FINSET_1, FUNCT_4, FINSEQ_1, INT_1;
+ requirements REAL, NUMERALS, SUBSET, BOOLE, ARITHM;
+ definitions TARSKI, ORDINAL1, XBOOLE_0, RELAT_1, PARTFUN1, CARD_1;
+ equalities ORDINAL1, FUNCOP_1, VALUED_1;
+ expansions TARSKI, ORDINAL1, RELAT_1, CARD_1, FUNCT_1;
+ theorems TARSKI, AXIOMS, FUNCT_1, NAT_1, ZFMISC_1, RELAT_1, RELSET_1,
+      ORDINAL1, CARD_1, FINSEQ_1, FUNCT_7, ORDINAL4, CARD_2, FUNCT_4, ORDINAL3,
+      XBOOLE_0, XBOOLE_1, FINSET_1, FUNCOP_1, XREAL_1, VALUED_0, ENUMSET1,
+      XXREAL_0, XREAL_0, GRFUNC_1, XXREAL_2, NAT_D, VALUED_1, XTUPLE_0,
+      FINSEQ_3, ORDINAL2, INT_1;
+ schemes FUNCT_1, SUBSET_1, NAT_1, XBOOLE_0, CLASSES1, FINSEQ_1;
+
+begin
+
+reserve k,n for Nat,
+  x,y,z,y1,y2 for object,X,Y for set,
+  f,g for Function;
+
+:: Extended Segments of Natural Numbers
+
+theorem Th0: ::: CHORD:1 moved eventually from there -> go to INT_1
+  for n being non zero Nat holds n-1 is Nat & 1 <= n
+  proof
+   let n be non zero Nat;
+A1: 0+1 <= n by NAT_1:13;
+   0+1-1 <= n-1 by A1, XREAL_1:9;
+   then n-1 in NAT by INT_1:3;
+   hence n-1 is Nat;
+   thus thesis by A1;
+end;
+
+theorem Th1:
+  Segm n \/ { n } = Segm(n+1)
+proof
+   n in Segm(n+1) by NAT_1:45;
+   then
+A1:{n} c= Segm(n+1) by ZFMISC_1:31;
+   Segm n c= Segm(n+1) by NAT_1:39,11;
+  hence Segm n \/ { n } c= Segm(n+1) by A1,XBOOLE_1:8;
+  let x be object;
+  assume
+A2: x in Segm(n+1);
+    then reconsider x as Nat;
+  now
+B1: x < n+1 by A2,NAT_1:44;
+  per cases by B1,NAT_1:22;
+   case x < n;
+    hence x in Segm n by NAT_1:44;
+   end;
+   case x = n;
+    hence x in {n} by TARSKI:def 1;
+   end;
+  end;
+ hence thesis by XBOOLE_0:def 3;
+end;
+
+theorem Th2:
+  Seg n c= Segm(n+1)
+proof
+  let x be object;
+  assume
+A1: x in Seg n;
+  then reconsider x as Element of NAT;
+  x<=n by A1,FINSEQ_1:1;
+  then x<n+1 by NAT_1:13;
+  hence thesis by NAT_1:44;
+end;
+
+theorem
+  n+1 = {0} \/ Seg n
+proof
+  thus n+1 c= {0} \/ Seg n
+  proof
+   let x be object;
+    assume x in n+1;
+    then x in {j where j is Nat: j<n+1} by AXIOMS:4;
+    then consider j being Nat such that
+A1: j=x and
+A2: j<n+1;
+C1: j=0 or 1<j+1 & j<=n by A2,NAT_1:13,XREAL_1:29;
+    j=0 or 1<=j & j<=n by C1,NAT_1:13;
+    then x in {0} or x in Seg n by A1,FINSEQ_1:1,TARSKI:def 1;
+    hence thesis by XBOOLE_0:def 3;
+  end;
+A3: Segm 1 c= Segm(n+1) by NAT_1:39,11;
+  Seg(n) c= Segm(n+1) by Th2;
+  hence thesis by A3,CARD_1:49,XBOOLE_1:8;
+end;

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -18,17 +18,33 @@ os.environ["ENV"] = "test"
 TEST_DIR = f"{os.getcwd()}/tests"
 
 lp_miz_controller = MizController()
-lp_miz_controller.exec_file(f"{TEST_DIR}/data/long_proof.miz", f"{TEST_DIR}/data/mml.vct")
+lp_miz_controller.exec_file(
+    f"{TEST_DIR}/data/long_proof.miz", f"{TEST_DIR}/data/mml.vct"
+)
 lp_ast_root = lp_miz_controller.ast_root
 
 
 def test_check_long_proof1(caplog):
-  setattr(option, "MAX_PROOF_LINE_NUMBER", 32)
-  check_long_proof(lp_ast_root)
-  assert "Proof too long" in caplog.text
+    setattr(option, "MAX_PROOF_LINE_NUMBER", 32)
+    check_long_proof(lp_ast_root)
+    assert "Proof too long" in caplog.text
 
 
 def test_check_long_proof2(caplog):
-  setattr(option, "MAX_PROOF_LINE_NUMBER", 33)
-  check_long_proof(lp_ast_root)
-  assert not "Proof too long" in caplog.text
+    setattr(option, "MAX_PROOF_LINE_NUMBER", 33)
+    check_long_proof(lp_ast_root)
+    assert not "Proof too long" in caplog.text
+
+
+rl_miz_controller = MizController()
+rl_miz_controller.exec_file(
+    f"{TEST_DIR}/data/redundant_label.miz", f"{TEST_DIR}/data/mml.vct"
+)
+rl_ast_root = rl_miz_controller.ast_root
+rl_token_table = rl_miz_controller.token_table
+
+
+def test_check_redundant_statement_label(caplog):
+    token_lines = generate_token_lines(rl_token_table)
+    check_redundant_statement_label(rl_ast_root, token_lines)
+    assert caplog.text.count("is redundant citation label") == 3


### PR DESCRIPTION
## 概要
直前の式の引用にthenを使えるところを検出し、警告を出す。

```
L1:A=B by ··· ;
// bad
L2:B=C by ··· ;
L3:A=C by L1,L2;
// good
B=C by ··· ;
then L3:A=C by L1;
```

## テスト
想定ログ出力
```sh
ERROR    root:linter.py:120 `A1` is redundant citation label. Use `then` to omit the label [Ln 56, Col 20]
ERROR    root:linter.py:120 `B1` is redundant citation label. Use `then` to omit the label [Ln 76, Col 16]
ERROR    root:linter.py:120 `C1` is redundant citation label. Use `then` to omit the label [Ln 111, Col 27]
```

## 備考
`check_long_proof` はフォーマットの差分なので確認の必要なし。

close #43 